### PR TITLE
Update code to work with API-breaking authentication changes made by AlienVault

### DIFF
--- a/alienvault_usm_anywhere/types.py
+++ b/alienvault_usm_anywhere/types.py
@@ -14,6 +14,11 @@ class Client:
         self.s = s
         self.domain = domain
 
+class AuthException(Exception):
+    """Exception raised for AlienVault authentication errors """
+    def __init__(self, r, message):
+        self.r = r
+        self.message = message
 
 class ClientException(Exception):
     """Exception raised for AlienVault client errors """
@@ -28,6 +33,8 @@ def dump_all(r):
 
 
 def raise_on_error(r):
-    if r.status_code != 200:
+    if r.status_code == 401:
+        raise AuthException(r, f"{r.status_code}: {r.content.decode('utf-8', 'strict')}")
+    elif r.status_code != 200:
         raise ClientException(r, f"{r.status_code}: {r.content.decode('utf-8', 'strict')}")
     return r

--- a/examples/show_configurations.py
+++ b/examples/show_configurations.py
@@ -14,7 +14,10 @@ import sys
 def main():
     subdomain = sys.argv[1]
     domain = "alienvault.cloud"
-    api_client = alienvault_usm_anywhere.client(f"{subdomain}.{domain}")
+
+    auth_cookies = alienvault_usm_anywhere.get_auth_cookies(f"{subdomain}.{domain}", "firefox")
+    api_client = alienvault_usm_anywhere.client(f"{subdomain}.{domain}", auth_cookies)
+
     correlation_lists = alienvault_usm_anywhere.correlation_lists(api_client)
     asset_groups = alienvault_usm_anywhere.asset_groups(api_client)
     orchestration_rules = alienvault_usm_anywhere.orchestration_rules(api_client)


### PR DESCRIPTION
The old method of authenticating with AlienVault no longer works due to some breaking change on their end. Because the changes made to the authentication process are difficult to pin down, a more fool-proof method that will be more resilient to further changes is outlined below: 

This workaround takes the `XSRF-TOKEN` and `JSESSIONID` cookies from an authenticated browser session and uses them as means of authenticating with the client. This no longer requires manual interaction with the CLI or the handling of user credentials. So long as the names of the `XSRF-TOKEN` and `JSESSIONID` cookies remain the same, this method should continue to work indefinitely. 

As well, this PR adds an `AuthException` to denote when an authentication error has occured. Expired cookies will cause this exception to be raised.